### PR TITLE
Prep for repo move to linkerd org

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@ FROM library/golang:1.7.3
 
 WORKDIR /go/src/namerctl
 
-ADD . /go/src/github.com/buoyantio/namerctl
+ADD . /go/src/github.com/linkerd/namerctl
 
-RUN go build -o /go/bin/namerctl /go/src/github.com/buoyantio/namerctl/main.go
+RUN go build -o /go/bin/namerctl /go/src/github.com/linkerd/namerctl/main.go
 
 ENTRYPOINT ["/go/bin/namerctl"]

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # namerctl #
 
-A utility for controlling [namerd](https://github.com/BuoyantIO/linkerd/tree/master/namerd).
+A utility for controlling [namerd](https://github.com/linkerd/linkerd/tree/master/namerd).
 
 This utility _will change_ drastically in the near future.
 
 ## Installation ##
 
 ```
-:; go get -u github.com/BuoyantIO/namerctl
-:; go install github.com/BuoyantIO/namerctl
+:; go get -u github.com/linkerd/namerctl
+:; go install github.com/linkerd/namerctl
 ```
 
 ## Usage ##

--- a/cmd/dtab.go
+++ b/cmd/dtab.go
@@ -9,7 +9,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/buoyantio/namerctl/namer"
+	"github.com/linkerd/namerctl/namer"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/buoyantio/namerctl/namer"
+	"github.com/linkerd/namerctl/namer"
 	"github.com/spf13/cobra"
 	//jww "github.com/spf13/jwalterweatherman"
 	"github.com/spf13/viper"

--- a/main.go
+++ b/main.go
@@ -1,6 +1,6 @@
 package main
 
-import "github.com/buoyantio/namerctl/cmd"
+import "github.com/linkerd/namerctl/cmd"
 
 func main() {
 	cmd.Execute()

--- a/release.sh
+++ b/release.sh
@@ -1,5 +1,5 @@
-GOOS=linux GOARCH=amd64  go build -o namerctl_linux_amd64 github.com/buoyantio/namerctl
-GOOS=linux GOARCH=386    go build -o namerctl_linux_i386  github.com/buoyantio/namerctl
-GOOS=darwin GOARCH=amd64 go build -o namerctl_darwin      github.com/buoyantio/namerctl
+GOOS=linux GOARCH=amd64  go build -o namerctl_linux_amd64 github.com/linkerd/namerctl
+GOOS=linux GOARCH=386    go build -o namerctl_linux_i386  github.com/linkerd/namerctl
+GOOS=darwin GOARCH=amd64 go build -o namerctl_darwin      github.com/linkerd/namerctl
 echo "releases built:"
 ls namerctl_*


### PR DESCRIPTION
Namerctl is moving to the linkerd org. Will merge this after the move happens.