### PR TITLE
Utilize multi-stage builds to build a (much!) smaller Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,13 @@
-FROM library/golang:1.7.3
+FROM library/golang:1.7.3 AS build-env
 
 WORKDIR /go/src/namerctl
 
 ADD . /go/src/github.com/linkerd/namerctl
 
-RUN go build -o /go/bin/namerctl /go/src/github.com/linkerd/namerctl/main.go
+RUN go build -ldflags "-linkmode external -extldflags -static" -o /go/bin/namerctl /go/src/github.com/linkerd/namerctl/main.go
 
-ENTRYPOINT ["/go/bin/namerctl"]
+FROM scratch
+
+COPY --from=build-env /go/bin/namerctl /namerctl
+
+ENTRYPOINT ["/namerctl"]


### PR DESCRIPTION
This builds a statically linked binary and puts it in a scratch image, instead of including the entire go build stack in the image. The new image is roughly 1.5 % (!!) of the old image in size.

```
> docker images namerd
REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
namerd              before              815934e72369        2 minutes ago       689MB
namerd              after               1790ad8ff8dc        3 minutes ago       11.2MB
```

To prove it still works 😉:

```
> docker run --rm namerd:after help
namerd manages delegation tables for linkerd.

namerctl looks for a configuration file in the current working
directory or any of its parent directories. Configuration files are
named .namerctl.<ext> where <ext> is describes one of several formats
including yaml, json, toml, etc.  "base-url" is currently the only
supported configuration.  Furthermore, the base url may be specified
via the NAMERCTL_BASE_URL environment variable.

Find more information at https://linkerd.io

Usage:
  namerctl [command]

Available Commands:
  dtab        Control namerd's delegation tables

Flags:
      --base-url string   namer location (e.g. http://namerd.example.com:4080)
      --config string     config file

Use "namerctl [command] --help" for more information about a command.
``` 